### PR TITLE
More coverity fixes

### DIFF
--- a/src/test/histogram_perf.c
+++ b/src/test/histogram_perf.c
@@ -78,8 +78,11 @@ int main() {
       gettimeofday(&finish, NULL);
       double elapsed = finish.tv_sec - start.tv_sec;
       elapsed += (finish.tv_usec/1000000.0) - (start.tv_usec/1000000.0);
-      printf("ops: %ld, time: %gs, time-per-op: %0.2fns\n",
+      if(cnt != 0)
+        printf("ops: %ld, time: %gs, time-per-op: %0.2fns\n",
              cnt, elapsed, (elapsed / (double)cnt) * 1000000000.0);
+      else 
+        printf("cannot calculate benchmark, no work done!\n");
       hist_free(hist);
       free(vals);
 }

--- a/src/test/histogram_test.c
+++ b/src/test/histogram_test.c
@@ -226,6 +226,7 @@ void q_test(double *vals, int nvals, double *in, int nin, double *expected) {
     for(i=0;i<nin;i++) {
       if(!double_equals(out[i], expected[i])) {
         notokf("q(%f) -> %g != %g", in[i], out[i], expected[i]);
+        free(out);
         return;
       }
     }
@@ -324,6 +325,7 @@ void compress_test() {
   T(is(hist_bucket_count(h) == 9));
   h = hist_compress_mbe(h, 2);
   T(is(hist_bucket_count(h) == 3));
+  hist_free(h);
   h = hist_compress_mbe(h, 3);
   T(is(hist_bucket_count(h) == 1));
   

--- a/src/test/histogram_test.c
+++ b/src/test/histogram_test.c
@@ -323,6 +323,7 @@ void compress_test() {
   T(is(hist_bucket_count(h) == 16));
   h = hist_compress_mbe(h, 1);
   T(is(hist_bucket_count(h) == 9));
+  hist_free(h);
   h = hist_compress_mbe(h, 2);
   T(is(hist_bucket_count(h) == 3));
   hist_free(h);


### PR DESCRIPTION
Caused by past fixes not fully appealing coverity.

*when adding `hist_free(h)` on line 328 I am uncertain if this will be a complete fix.  I may have to check coverity and make another change*