### PR TITLE
Fix and clenaup python/lua FFI binging generation

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -111,11 +111,16 @@ test/histogram_test: test/histogram_test.c $(LIBCIRCLLHIST)
 test/histogram_perf: test/histogram_perf.c $(LIBCIRCLLHIST)
 	$(Q)$(CC) -I. $(CPPFLAGS) $(CFLAGS) -L. $(LDFLAGS) -I. -o $@ test/histogram_perf.c -lcircllhist -lm
 
-$(LUA_FFI):	circllhist.h
-	./generateLuaFiles.sh . $@
+circllhist.ffi.h: circllhist.h
+	./prepareFFI.sh < $< > $@
 
-$(PYTHON_FFI):	circllhist.h
-	./generatePythonFiles.sh . $@
+$(LUA_FFI): circllhist.ffi.h
+	mkdir -p $$(dirname $@)
+	./generateLuaFiles.sh < $< > $@
+
+$(PYTHON_FFI): circllhist.ffi.h
+	mkdir -p $$(dirname $@)
+	./generatePythonFiles.sh < $< > $@
 
 .c.lo:
 	@echo "- compiling $<"
@@ -152,6 +157,9 @@ install-python:
 
 tests: test/histogram_test test/histogram_perf $(LUA_FFI)
 	test/runTest.sh
+
+tests-python:
+	python python/test.py
 
 clean:
 	rm -f *.lo *.o $(TARGETS)

--- a/src/circllhist.h
+++ b/src/circllhist.h
@@ -33,7 +33,7 @@
 #define CIRCLLHIST_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C" { /* FFI_SKIP */
 #endif
 
 #define DEFAULT_HIST_SIZE 100
@@ -198,7 +198,7 @@ API_EXPORT(double) hist_approx_sum(const histogram_t *);
 API_EXPORT(int) hist_approx_quantile(const histogram_t *, const double *q_in, int nq, double *q_out);
 
 #ifdef __cplusplus
-}
+} /* FFI_SKIP */
 #endif
 
 #endif

--- a/src/generateLuaFiles.sh
+++ b/src/generateLuaFiles.sh
@@ -1,36 +1,15 @@
 #!/bin/sh
 
-if [ $# -lt 2 ]
-then
-  echo "Usage: $0 <libcircllhist_src_dir> <destination_file>"
-  exit
-fi
+STDIN=$(cat)
 
-src_dir=$1
-dst_file=$2
-
-if [ -x /usr/bin/gsed ]; then
-    SED=gsed
-else
-    SED=sed
-fi
-AWK=awk
-
-cdef_content=`cat $src_dir/circllhist.h | egrep -v "#if|#endif|#define|#include" | $SED 's/u_int/uint/g' | $SED 's/API_EXPORT(\([^\)]*\))/\1/g' | $AWK '/typedef struct histogram histogram_t;/ {print "typedef long int ssize_t;"} /^extern "C" {/{next} /^\/\//{next}  /^}$/{next} /./{print}'`
-
-D=`dirname $dst_file`
-if [ ! -e $D ]; then
-    mkdir $D
-fi
-
-cat > $dst_file <<EOF
+cat <<EOF
 local ffi = require('ffi');
 
 --------------------------------------------------------------------------------
 -- circllhist.h
 --------------------------------------------------------------------------------
 ffi.cdef[[
-${cdef_content}
+${STDIN}
 ]]
 
 return ffi.load("libcircllhist")

--- a/src/generatePythonFiles.sh
+++ b/src/generatePythonFiles.sh
@@ -1,33 +1,12 @@
 #!/bin/sh
 
-if [ $# -lt 2 ]
-then
-  echo "Usage: $0 <libcircllhist_src_dir> <destination_file>"
-  exit
-fi
+STDIN=$(cat)
 
-src_dir=$1
-dst_file=$2
-
-if [ -x /usr/bin/gsed ]; then
-    SED=gsed
-else
-    SED=sed
-fi
-AWK=awk
-
-cdef_content=`cat $src_dir/circllhist.h | egrep -v "#if|#endif|#define|#include" | $SED 's/u_int/uint/g' | $SED 's/API_EXPORT(\([^\)]*\))/\1/g' | $AWK '/typedef struct histogram histogram_t;/ {print "typedef long int ssize_t;"} /./{print}'`
-
-D=`dirname $dst_file`
-if [ ! -e $D ]; then
-    mkdir -p $D
-fi
-
-cat > $dst_file <<EOF
+cat <<EOF
 from cffi import FFI
 ffi = FFI()
 ffi.cdef("""
-${cdef_content}
+${STDIN}
 """)
 C = None
 for path in [ # Search for libcircllhist.so

--- a/src/prepareFFI.sh
+++ b/src/prepareFFI.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -x /usr/bin/gsed ]; then
+    SED=gsed
+else
+    SED=sed
+fi
+AWK=awk
+
+cat |\
+  grep -v -F '/* FFI_SKIP */' |\
+  grep -v "^$" |\
+  $SED 's|//.*$||' |\
+  egrep -v "#if|#endif|#define|#include" |\
+  $SED 's/u_int/uint/g' |\
+  $SED 's/API_EXPORT(\([^\)]*\))/\1/g' |\
+  $AWK '/typedef struct histogram histogram_t;/ {print "typedef long int ssize_t;"} /./{print}'


### PR DESCRIPTION
Lua and Python FFI bindings need the same preprocessing. Factor this out into a separate make target.

We already had problems with generate*.sh going out of sync with somewhat recent `extern C { ... }` addition that was not present in the feature branch #30. This is fixed now as well.
Instead of the `awk /extern C/...` I opted for explicitly marking the lines that should be skipped with a `#FFI_SKIP` marker in circllhist.h