### PR TITLE
Build on Windows

### DIFF
--- a/src/circllhist.c
+++ b/src/circllhist.c
@@ -35,10 +35,13 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <string.h>
-#include <sys/socket.h>
 #include <math.h>
-#include <arpa/inet.h>
 #include <ctype.h>
+
+#if !defined(WIN32)
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#endif
 
 #include "circllhist.h"
 
@@ -115,10 +118,19 @@ struct hist_flevel {
 };
 
 //! A bucket-count pair
+#if defined(WIN32)
+#pragma pack(push, 1)
+struct hist_bv_pair {
+  hist_bucket_t bucket;
+  uint64_t count;
+};
+#pragma pack(pop)
+#else
 struct hist_bv_pair {
   hist_bucket_t bucket;
   uint64_t count;
 }__attribute__((packed));
+#endif
 
 //! The histogram structure
 //! Internals are regarded private and might change with version.
@@ -1199,7 +1211,7 @@ hist_free(histogram_t *hist) {
     struct histogram_fast *hfast = (struct histogram_fast *)hist;
     for(i=0;i<256;i++) a->free(hfast->faster[i]);
   }
-  
+
   a->free(hist);
 }
 

--- a/src/circllhist.h
+++ b/src/circllhist.h
@@ -36,6 +36,11 @@
 #ifndef CIRCLLHIST_H
 #define CIRCLLHIST_H
 
+#if defined(WIN32)
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #ifdef __cplusplus
 extern "C" { /* FFI_SKIP */
 #endif

--- a/src/prepareFFI.sh
+++ b/src/prepareFFI.sh
@@ -22,7 +22,7 @@ cat |\
   $GREP -v -F '/* FFI_SKIP */' |\
   $GREP -v "^$" |\
   $SED 's|//.*$||' |\
-  $EGREP -v "#if|#endif|#define|#include" |\
+  $EGREP -v "#if|#endif|#define|#include|SSIZE_T" |\
   $SED 's/u_int/uint/g' |\
   $SED 's/API_EXPORT(\([^\)]*\))/\1/g' |\
   $AWK '/typedef struct histogram histogram_t;/ {print "typedef long int ssize_t;"} /./{print}'


### PR DESCRIPTION
We've verified that this change successfully builds on both Windows and Linux. For context, we are working on adding Windows support to Envoy (https://github.com/envoyproxy/envoy/issues/129) and this library is a dependency.