### PR TITLE
Don't use __builtin_expect on Windows

### DIFF
--- a/src/circllhist.c
+++ b/src/circllhist.c
@@ -69,7 +69,11 @@ static const hist_bucket_t hbnan = { (int8_t)0xff, 0 };
 } while(0)
 #define ASSERT_GOOD_BUCKET(hb) assert(hist_bucket_is_valid(hb))
 #else
+#ifdef WIN32
+#define unlikely(x) (x)
+#else
 #define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
 #define ASSERT_GOOD_HIST(h)
 #define ASSERT_GOOD_BUCKET(hb)
 #endif


### PR DESCRIPTION
`__builtin_expect` is not supported by MSVC.

We've verified that this builds on Windows, and that `make tests` passes on Linux