### PR TITLE
Quantile improvements

### DIFF
--- a/src/circllhist.c
+++ b/src/circllhist.c
@@ -581,12 +581,12 @@ hist_approx_count_below(const histogram_t *hist, double threshold) {
   for(i=0; i<hist->used; i++) {
     if(hist_bucket_isnan(hist->bvs[i].bucket)) continue;
     double bucket_bound = hist_bucket_to_double(hist->bvs[i].bucket);
-    double bucket_upper;
+    double bucket_lower;
     if(bucket_bound < 0.0)
-      bucket_upper = bucket_bound;
+      bucket_lower = bucket_bound - hist_bucket_to_double_bin_width(hist->bvs[i].bucket);
     else
-      bucket_upper = bucket_bound + hist_bucket_to_double_bin_width(hist->bvs[i].bucket);
-    if(bucket_upper <= threshold)
+      bucket_lower = bucket_bound;
+    if(bucket_lower <= threshold)
       running_count += hist->bvs[i].count;
     else
       break;

--- a/src/circllhist.c
+++ b/src/circllhist.c
@@ -542,7 +542,6 @@ hist_approx_stddev(const histogram_t *hist) {
   double s2 = 0.0;
   if(!hist) return private_nan;
   ASSERT_GOOD_HIST(hist);
-  if(hist->used == 0) return 0.0;
   for(i=0; i<hist->used; i++) {
     if(hist_bucket_isnan(hist->bvs[i].bucket)) continue;
     double midpoint = hist_bucket_midpoint(hist->bvs[i].bucket);

--- a/src/lua/circllhist.lua
+++ b/src/lua/circllhist.lua
@@ -1,0 +1,395 @@
+module(..., package.seeall)
+--
+-- circllhist.lua
+--
+-- This module is a wrapper around the ffi_libcircllhist library.
+-- It defines an ffi_metatype that provides:
+--
+-- - constructors that return garbage collected values
+--
+-- - object like operations on histogram_t values, e.g. `H:count()`
+--
+-- - sanity checking of arguments.
+--
+
+local ffi = require('ffi');
+local libhist = require "ffi_libcircllhist"
+
+ffi.cdef[[
+void* malloc (size_t size);
+void free (void* ptr);
+]]
+
+-- From circllhist.c
+local HIST_APPROX_QUANTILE_ERRORS = {
+  [0]  = "success",
+  [-1] = "empty histogram",
+  [-2] = "out of order quantile request",
+  [-3] = "out of bound quantile"
+}
+
+local function isnan(x)
+  return not (x == x)
+end
+
+--
+-- Histogram Class
+--
+local Circllhist = {}
+Circllhist.__index = Circllhist
+local ffi_histogram_t = ffi.typeof("histogram_t")
+
+--
+-- Constructor
+--
+
+-- Primary Constructor
+function Circllhist.new()
+  local hist = libhist.hist_alloc()
+  assert(hist)
+  ffi.gc(hist, libhist.hist_free)
+  return hist
+end
+
+--- Create circllhist from table of double values
+function Circllhist.from_data(data)
+  local hist = Circllhist:new()
+  for _, y in ipairs(data) do
+    libhist.hist_insert(hist, y, 1)
+  end
+  return hist
+end
+
+--- Create circllhist from a table that maps value => count
+function Circllhist.from_map(map)
+  local hist = Circllhist:new()
+  for value, count in pairs(map) do
+    libhist.hist_insert(hist, value, count)
+  end
+  return hist
+end
+
+--- Create circllhist from a base64 encoded string
+-- string_len is optional
+function Circllhist.from_base64(b64_string, string_len)
+  local hist = Circllhist:new()
+  if string_len == nil then
+    string_len = string.len(b64_string)
+  end
+  libhist.hist_deserialize_b64(hist, b64_string, string_len)
+  return hist
+end
+
+-- Create circllhist from ffi ptr to a histogram_t structure
+-- If the parameter gc == true, we garbage collect the structure
+-- after we are done with it.
+function Circllhist.from_ffi_ptr(ptr, gc)
+  local hist = ffi.cast("histogram_t*", ptr)
+  if gc then
+    ffi.gc(hist, libhist.hist_free)
+  end
+  return hist
+end
+
+--
+-- Static Helper Functions
+--
+function Circllhist.is_instance(obj)
+  return ffi.istype(ffi_histogram_t, obj)
+end
+
+function Circllhist.number_to_bucket(d)
+  local bucket = libhist.double_to_hist_bucket(d)
+  if bucket.exp == 0 and bucket.val == -1 then
+    return nil
+  end
+  return bucket.val/10 * math.pow(10, bucket.exp)
+end
+
+function Circllhist.bucket_size(bucket_bound)
+  local bucket = libhist.double_to_hist_bucket(bucket_bound)
+  return libhist.hist_bucket_to_double_bin_width(bucket)
+end
+
+function Circllhist.bucket_mid(bucket_bound)
+  local bucket = libhist.double_to_hist_bucket(bucket_bound)
+  return libhist.hist_bucket_midpoint(bucket)
+end
+
+--
+-- Mutators
+--
+
+-- clear all data from histogram
+function Circllhist:clear()
+  libhist.hist_clear(self)
+end
+
+-- Merge data from other_hist into self
+function Circllhist:merge(other_hist)
+  if other_hist == nil then return end
+  local other_hist_ptr = ffi.new("const histogram_t*[1]", other_hist)
+  libhist.hist_accumulate(self, other_hist_ptr, 1)
+end
+
+---- insert data into the histogram
+--@param value, this does *not* need to be a bucket boundary
+--@param count, how many samples of that value to insert, default = 1
+function Circllhist:insert(value, count)
+  assert(value)
+  libhist.hist_insert(self, value, count or 1)
+  return self
+end
+
+--
+-- Iteration Methods
+--
+local _hist_iter_next -- forward declaration
+_hist_iter_next = function(param, state)
+  local idx = state
+  if idx > param.limit then
+    return nil -- end iteration
+  end
+  local val, count = param.self:bucket_idx(idx)
+  if count == 0 then
+    -- this is a tail call. No new stack frame will be allocated.
+    return _hist_iter_next(param, idx + 1)
+  end
+  return idx + 1, val, count
+end
+
+-- returns a stateless lua iterator, to be used as:
+-- for _, bin, cnt in hist:iter() do ..
+function Circllhist:iter()
+  local param = { self = self, limit = self:bucket_count()-1 }
+  local state = 0
+  return _hist_iter_next, param, state
+end
+
+--
+-- Exporters
+--
+
+-- returns histogram as a new map object
+function Circllhist:to_map()
+  local map = {}
+  for _, bin, count in self:iter() do
+    if isnan(bin) then
+      map['nan'] = count
+    else
+      map[bin] = count
+    end
+  end
+  return map
+end
+
+-- returns histogram as a human readable string
+function Circllhist:__tostring()
+  local buf = {}
+  local total = 0
+  for _, bin, count in self:iter() do
+    table.insert(buf, string.format("%.2g:%d", bin, count))
+    total = total + count
+  end
+  return string.format("Hist[%d]{%s}", total, table.concat(buf, ", "))
+end
+
+-- returns histogram as a base64 encoded string
+function Circllhist:base64()
+  local buf_length = libhist.hist_serialize_b64_estimate(self)
+  local buf = ffi.gc(ffi.C.malloc(buf_length), ffi.C.free)
+  assert(buf)
+  local string_length = libhist.hist_serialize_b64(self, buf, buf_length)
+  return ffi.string(buf, string_length)
+end
+
+-- for __tojson
+local ffi_bucket_str_buffer = ffi.new("char[128]")
+local function ffi_hist_bucket_to_string(ffi_bucket, format)
+  if format == "double" then
+    local bucket_str_len = libhist.hist_bucket_to_string(ffi_bucket, ffi_bucket_str_buffer)
+    return ffi.string(ffi_bucket_str_buffer, bucket_str_len)
+  elseif format == "hex" then
+    return '0x' .. bit.tohex(bit.bor(ffi_bucket.exp, bit.lshift(ffi_bucket.val,8)), 4)
+  else
+    return string.format(format, libhist.hist_bucket_to_double(ffi_bucket))
+  end
+end
+
+--- fast, standartized JSON encoder
+function Circllhist:tojson(state)
+  local hist_bucket_format = (state and state.hist_bucket_format) or "double"
+  local buf = {}
+  table.insert(buf,"{")
+  local total = self:bucket_count()
+  for idx = 0, total-1 do
+    local ffi_bucket = ffi.new("hist_bucket_t")
+    local ffi_count = ffi.new("uint64_t[1]")
+    libhist.hist_bucket_idx_bucket(self, idx, ffi_bucket, ffi_count)
+    local bin_count = tonumber(ffi_count[0])
+    table.insert(buf,string.format('"%s":%d', ffi_hist_bucket_to_string(ffi_bucket, hist_bucket_format), bin_count))
+    if idx < total-1 then
+      table.insert(buf, ',')
+    end
+  end
+  table.insert(buf, "}")
+  return table.concat(buf)
+end
+-- This meta function will be used by dkjson
+Circllhist.__tojson = Circllhist.tojson
+
+
+--
+-- Methods
+--
+
+-- returns the number of used buckets
+function Circllhist:bucket_count()
+  return libhist.hist_bucket_count(self)
+end
+
+-- returns value, count of the bucket with given index
+function Circllhist:bucket_idx(bucket_id)
+  assert(0 <= bucket_id and bucket_id < self:bucket_count())
+  local value =  ffi.new("double[1]")
+  local count =  ffi.new("uint64_t[1]")
+  libhist.hist_bucket_idx(self, bucket_id, value, count)
+  return tonumber(value[0]), tonumber(count[0])
+end
+
+-- returns true if the histogram is empty
+function Circllhist:isempty()
+  -- We don't use hist_bucket_count() here b/c we have seen histograms
+  -- with used buckets but 0 total count in the wild before.
+  return self:count() == 0
+end
+
+function Circllhist:isequal(other_hist)
+  if not Circllhist.is_instance(other_hist) then
+    return false
+  end
+  local cnt = self:bucket_count()
+  if other_hist:bucket_count() ~= cnt then
+    return false
+  end
+  for i = 0, cnt-1 do
+    local b1, c1 = self:bucket_idx(i)
+    local b2, c2 = other_hist:bucket_idx(i)
+    if not b1 == b2 then return false end
+    if not c1 == c2 then return false end
+  end
+  return true
+end
+
+-- returns the number of samples represented by the histogram
+function Circllhist:count()
+  return tonumber(libhist.hist_sample_count(self))
+end
+
+-- returns the approximated standard deviation of the samples represented
+-- by the histogram
+function Circllhist:stddev()
+  return libhist.hist_approx_stddev(self)
+end
+
+-- returns the approximated k-th moment of the samples represented
+-- by the histogram
+function Circllhist:moment(k)
+  return libhist.hist_approx_moment(self, k)
+end
+
+-- returns the approximated mean of the samples represented
+-- by the histogram
+function Circllhist:mean()
+  return libhist.hist_approx_mean(self)
+end
+
+-- returns the approximated sum of of the samples represented
+-- by the histogram
+function Circllhist:sum()
+  return libhist.hist_approx_sum(self)
+end
+
+--- returns the approximated quantiles of the samples represented
+-- by the histogram
+-- - quantiles have to be sorted in ascending order
+-- - We compute Type-1 quantiles of the Hyndman Fan list
+-- - returns nil if the histogram is empty
+function Circllhist:quantiles(...)
+  local quantiles = {...}
+  local q_in = ffi.new("double[?]", #quantiles, quantiles)
+  local q_out = ffi.new("double[?]", #quantiles, 0/0)
+  local rc = libhist.hist_approx_quantile(self, q_in, #quantiles, q_out)
+  if rc ~= 0 then
+    rc = HIST_APPROX_QUANTILE_ERRORS[rc] or tostring(rc)
+    error("hist_approx_quantile failed with: " .. rc)
+  end
+  local out = {}
+  for i=1,#quantiles do
+    out[i] = q_out[i-1]
+  end
+  return unpack(out)
+end
+
+-- returns ratios of samples that are lower than the provided values.
+-- E.g.
+-- a, b = inverse_quantiles(10, 15)
+-- a = ratio of samples <10
+-- b = ratio of samples <15
+function Circllhist:inverse_quantiles(...)
+  local thresholds = {...}
+  local iq_in = ffi.new("double[?]", #thresholds, thresholds)
+  local iq_out = ffi.new("double[?]", #thresholds, 0/0)
+  local rc = libhist.hist_approx_inverse_quantile(self, iq_in, #thresholds, iq_out)
+  if rc ~= 0 then
+    rc = HIST_APPROX_QUANTILE_ERRORS[rc] or tostring(rc)
+    error("hist_approx_inverse_quantile failed with: " .. rc)
+  end
+  local out = {}
+  for i = 1, #thresholds do
+    out[i] = iq_out[i-1]
+  end
+  return unpack(out)
+end
+
+--- returns the number of values in a histogram that are in buckets
+--- that are entirely lower or equal than a given value.
+function Circllhist:count_below(...)
+  local out = {}
+  for i = 1, select("#", ...) do
+    out[i] = libhist.hist_approx_count_below(self, select(i, ...))
+  end
+  return unpack(out)
+end
+
+--- returns the number of values in a histogram that are in buckets
+--- that are entirely larger or equal than a given value.
+function Circllhist:count_above(...)
+  local out = {}
+  for i = 1, select("#", ...) do
+    out[i] = libhist.hist_approx_count_above(self, select(i, ...))
+  end
+  return unpack(out)
+end
+
+--- returns the number of values in a histogram that are in buckets
+--- the same bucket as the provided values
+function Circllhist:count_nearby(...)
+  local out = {}
+  for i = 1, select("#", ...) do
+    out[i] = libhist.hist_approx_count_nearby(self, select(i, ...))
+  end
+  return unpack(out)
+end
+
+--- returns a compressed version of the histogram, where
+-- bins with exponents smaller than "mbe" have been squashed
+-- into 0.
+function Circllhist:compress_mbe(mbe)
+  local hist_ptr = libhist.hist_compress_mbe(self, mbe)
+  return Circllhist.from_ffi_ptr(hist_ptr, true)
+end
+
+ffi.metatype(ffi_histogram_t, Circllhist)
+
+return Circllhist

--- a/src/python/test.py
+++ b/src/python/test.py
@@ -13,7 +13,7 @@ class TestHistogram(unittest.TestCase):
         self.assertEqual(h.bin_count(), 2)
         self.assertAlmostEqual(h.sum(), 385.5)
         self.assertAlmostEqual(h.mean(), 96.375)
-        self.assertAlmostEqual(h.quantile(0.5), 123.333, 1)
+        self.assertAlmostEqual(h.quantile(0.5), 122.5, 1)
         self.assertTrue(str(h))
         g = Circllhist.from_dict(h.to_dict())
         self.assertEqual(h.sum(), g.sum())

--- a/src/test/circllhist_test.lua
+++ b/src/test/circllhist_test.lua
@@ -1,0 +1,212 @@
+module(..., package.seeall)
+
+local Circllhist = require "circllhist"
+
+local writer = io.write
+
+local function assert(cond)
+  if not cond then
+    error("Assertion Failed")
+  end
+  writer(".")
+end
+
+local function isnan(x)
+  return not (x == x)
+end
+
+local function sim(x, y)
+  return string.format("%.3f", x) == string.format("%.3f", y)
+end
+
+local function setup(scratch)
+  scratch.hist = Circllhist.new();
+end
+
+local function teardown(scratch)
+end
+
+local function randhist(N)
+  local hist = Circllhist:new()
+  for i=1,N do
+    x = 10^math.random(-100,100) * math.random(1,99)
+    hist:insert(x)
+  end
+  return hist
+end
+
+local tests = {}
+
+function runTests()
+  for test_name,test in pairs(tests) do
+    writer("Test " .. test_name .. ": ")
+    local scratch = {}
+    setup(scratch)
+    test(scratch)
+    teardown(scratch)
+    writer(" SUCCESS\n")
+  end
+end
+
+function tests.empty(scratch)
+  local hist = scratch.hist
+  assert(Circllhist.is_instance(hist))
+  for _,b,v in hist:iter() do
+    error("We should not have any buckets")
+  end
+  assert(hist:bucket_count() == 0)
+  assert(hist:count() == 0)
+  assert(isnan(hist:mean()))
+  assert(isnan(hist:stddev()))
+  assert(hist:sum() == 0)
+  assert(isnan(hist:moment(0)))
+  assert(isnan(hist:moment(1)))
+  assert(isnan(hist:moment(2)))
+  assert(isnan(hist:quantiles(0)))
+  assert(isnan(hist:inverse_quantiles(100)))
+  assert(hist:count_below(100) == 0)
+  assert(hist:count_above(100) == 0)
+  assert(hist:count_nearby(100) == 0)
+end
+
+function tests.single(scratch)
+  local hist = scratch.hist
+  hist:insert(100)
+  assert(Circllhist.is_instance(hist))
+  local flag = false
+  for _,b, v in hist:iter() do
+    assert(b == 100)
+    assert(v == 1)
+    flag = true
+  end
+  assert(flag)
+  local bin, cnt = hist:bucket_idx(0)
+  assert(bin == 100)
+  assert(cnt == 1)
+  assert(hist:bucket_count() == 1)
+  assert(hist:count() == 1)
+  assert(hist:mean() == 105)
+  assert(hist:stddev() == 0)
+  assert(hist:sum() == 105)
+  assert(hist:moment(0) == 1)
+  assert(hist:moment(1) == 105 )
+  assert(hist:moment(2) ==  105 * 105)
+  assert(hist:quantiles(0) == 105)
+  assert(hist:inverse_quantiles(100) == 0)
+  assert(hist:count_below(100) == 1)
+  assert(hist:count_above(100) == 1)
+  assert(hist:count_nearby(100) == 1)
+end
+
+function tests.quantile_single(scratch)
+  local hist = scratch.hist
+  hist:insert(100)
+
+  -- a single sample will be located at the bin midpoint
+  local mid = Circllhist.bucket_mid(100)
+  local q = {0, .1, .2, .5, .8, .9, 1}
+  local Y = {hist:quantiles(unpack(q))}
+  for _,y in ipairs(Y) do
+    assert(y == mid)
+  end
+end
+
+function tests.quantile_two(scratch)
+  local hist = scratch.hist
+  hist:insert(100, 2)
+  -- We expect quantiles at 100 + k*10/3, k=1,2
+  local ml = 100 + 10/3
+  local mh  = 100 + 2*10/3
+  local q = {0,  .1, .2, .5, .50005, .6, .9,  1}
+  local Z = {ml, ml, ml, ml,     mh, mh, mh, mh}
+  local Y = {hist:quantiles(unpack(q))}
+  for i,z in ipairs(Z) do
+    assert(sim(Y[i],z))
+  end
+end
+
+function tests.quantile_multi_bin(scratch)
+  local hist = scratch.hist
+  hist:insert(100, 1)
+  hist:insert(110, 1)
+  local q = {0,    .1,  .2,  .5,  .6,  .9,   1 }
+  local Z = {105, 105, 105, 105, 115, 115, 115 }
+  local Y = {hist:quantiles(unpack(q))}
+  for i,z in ipairs(Z) do
+    assert(sim(Y[i],z))
+  end
+end
+
+function tests.quantile_multi_bin_3(scratch)
+  local hist = scratch.hist
+  hist:insert(100, 1)
+  hist:insert(110, 1)
+  hist:insert(200, 1)
+  local q = {0,    .1,  .3,  .5,  .8,  .9,   1 }
+  local Z = {105, 105, 105, 115, 205, 205, 205 }
+  local Y = {hist:quantiles(unpack(q))}
+  for i,z in ipairs(Z) do
+    assert(sim(Y[i],z))
+  end
+end
+
+function tests.equal(scratch)
+  local h = Circllhist:new()
+  local k = Circllhist:new()
+  assert(h:isequal(k))
+  h:insert(100)
+  k:insert(100)
+  assert(h:isequal(k))
+  h:insert(0)
+  assert(not h:isequal(k))
+end
+
+function tests.base64(scratch)
+  local hist = randhist(100)
+  local other_hist = Circllhist.from_base64(hist:base64())
+  assert(hist:isequal(other_hist))
+end
+
+function tests.map(scratch)
+  local hist = randhist(100)
+  local map = hist:to_map()
+  local other_hist = Circllhist.from_map(map)
+  assert(hist:isequal(other_hist))
+end
+
+function tests.from_data(scratch)
+  local hist = scratch.hist
+  hist:insert(1)
+  hist:insert(2)
+  hist:insert(3)
+  local other_hist = Circllhist.from_data({1,2,3})
+  assert(hist:isequal(other_hist))
+end
+
+function tests.merge(scratch)
+  local hist = scratch.hist
+  hist:insert(1)
+  hist:insert(2)
+  hist:insert(3)
+  local hist2 = Circllhist.from_data({1,2,3})
+  hist:merge(hist2)
+  hist:merge(hist2)
+  local other_hist = Circllhist.from_map({
+      [1] = 3,
+      [2] = 3,
+      [3] = 3,
+  })
+  assert(hist:isequal(other_hist))
+end
+
+function tests.tojson(scratch)
+  local hist = Circllhist.from_data { 0, 1, 2, 3, 100, -100 }
+  local json = hist:tojson()
+  assert([[{"-10e+001":1,"0":1,"+10e-001":1,"+20e-001":1,"+30e-001":1,"+10e+001":1}]] == json)
+end
+
+function tests.mbe(scratch)
+  local hist = Circllhist.from_data { 10^1, 10^2, 10^3, 10^4 }
+  local other_hist = Circllhist.from_data { 0, 0, 10^3, 10^4 }
+  assert(other_hist:isequal(hist:compress_mbe(3)))
+end

--- a/src/test/histogram_c_test.lua
+++ b/src/test/histogram_c_test.lua
@@ -1,72 +1,52 @@
 module(..., package.seeall)
 
+
 local ffi = require('ffi');
-local histo_lib = require "ffi_libcircllhist"
+local circllhist = require "ffi_libcircllhist"
 
-local tester = {}
-local histo
 local writer = io.write
-local success = function() writer("SUCCESS\n") end
-local failed = false
-local fail = function() writer("FAIL\n"); failed = true end
 
-function tester.setup(scratch)
-  histo = histo_lib.hist_alloc();
+local function assert(cond)
+  if not cond then
+    error("Assertion Failed")
+  end
+  writer(".")
 end
 
-function tester.teardown(scratch)
-  histo_lib.hist_free(histo);
+local function setup(scratch)
+  scratch.hist = circllhist.hist_alloc();
 end
 
-function tester.test1_default_empty()
-  writer("test1_default_empty()...")
-  if histo_lib.hist_bucket_count(histo) == 0 then
-    success()
-  else
-    fail()
-  end
+local function teardown(scratch)
+  circllhist.hist_free(scratch.hist);
 end
 
-function tester.test2_single_bucket()
-  writer("test2_single_bucket()...\n")
-  writer("  single insert, single bucket...")
-  histo_lib.hist_insert(histo, 3.1, 5)
-  if histo_lib.hist_bucket_count(histo) == 1 then
-    success()
-  else
-    fail()
-  end
+local tests = {}
+function tests.default_empty(scratch)
+  assert(circllhist.hist_bucket_count(scratch.hist) == 0)
+end
 
-  writer("  single bucket, approx mean...")
-  if histo_lib.hist_approx_mean(histo) == 3.15 then
-    success()
-  else
-    fail()
-  end
+function tests.single_bucket(scratch)
+  local hist = scratch.hist
+  circllhist.hist_insert(hist, 3.1, 5)
+
+  assert(circllhist.hist_bucket_count(hist) == 1)
+  assert(circllhist.hist_approx_mean(hist) == 3.15)
 
   local value =  ffi.new("double[1]")
   local count =  ffi.new("uint64_t[1]")
-  histo_lib.hist_bucket_idx(histo, 0, value, count)
-
-  writer("  single bucket, value read...")
-  if value[0] == 3.1 then
-    success()
-  else
-    fail()
-  end
-
-  writer("  single bucket, count read...")
-  if count[0] == 5 then
-    success()
-  else
-    fail()
-  end
+  circllhist.hist_bucket_idx(hist, 0, value, count)
+  assert(value[0] == 3.1)
+  assert(count[0] == 5)
 end
 
 function runTests()
-    tester.setup()
-    tester.test1_default_empty()
-    tester.test2_single_bucket()
-    tester.teardown()
-    if failed then os.exit(-1) end
+  for test_name,test in pairs(tests) do
+    writer("Test " .. test_name .. ": ")
+    local scratch = {}
+    setup(scratch)
+    test(scratch)
+    teardown(scratch)
+    writer(" SUCCESS\n")
+  end
 end

--- a/src/test/histogram_test.c
+++ b/src/test/histogram_test.c
@@ -263,7 +263,7 @@ void simple_clear() {
   double out[1], in[1] = {0};
   hist_insert_intscale(h, 1, 0, 1);
   hist_approx_quantile(h, in, 1, out);
-  if(out[0] != 1) notokf("preclear q(0) -> %g != 1", out[0]);
+  if(out[0] != 1.05) notokf("preclear q(0) -> %g != 1", out[0]);
   else ok();
   hist_clear(h);
   out[0] = 0;
@@ -476,25 +476,25 @@ static void issue_n() {
 
   double in[9] = {0, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 0.999, 1};
   double out[9];
-  hist_approx_quantile(main_thread_interval_hist, in, 9,out);
+  hist_approx_quantile(main_thread_interval_hist, in, 9, out);
 
   const histogram_t* const hist_array[1] = { per_thread_interval_hist };
   hist_accumulate(main_thread_interval_hist, hist_array, 1);
   hist_clear(per_thread_interval_hist);
 
   hist_insert_intscale(per_thread_interval_hist, 2, 0, 1);
-  hist_approx_quantile(per_thread_interval_hist, in, 9,out);
-  isf(out[0] == 2, " min==2.0 != %g", out[0]);
+  hist_approx_quantile(per_thread_interval_hist, in, 9, out);
+  isf(out[0] == 2.05, " min==2.0 != %g", out[0]);
 
   main_thread_interval_hist = hist_alloc();
   hist_accumulate(main_thread_interval_hist, hist_array, 1);
-  hist_approx_quantile(main_thread_interval_hist, in, 9,out);
-  isf(out[0] == 2, "min==1.0 != %g", 2.0);
+  hist_approx_quantile(main_thread_interval_hist, in, 9, out);
+  isf(out[0] == 2.05, "min==1.0 != %g", 2.0);
 
   histogram_t* direct_hist = hist_alloc();
   hist_insert_intscale(direct_hist, 2, 0, 1);
   hist_approx_quantile(direct_hist, in, 9,out);
-  isf(out[0] == 2, " min==2.0 != %g", out[0]);
+  isf(out[0] == 2.05, " min==2.0 != %g", out[0]);
 }
 
 void
@@ -569,34 +569,44 @@ int main() {
   halloc = hist_alloc;
 
   iq_test();
-  
+
   for(int ai=0; ai<2; ai++) {
     double s1[] = { 0.123, 0, 0.43, 0.41, 0.415, 0.2201, 0.3201, 0.125, 0.13 };
     T(mean_test(s1, 9, 0.24444));
 
     double h[] = { 1 };
     double qin[] = { 0, 0.25, 0.5, 1 };
-    double qout[] = { 1, 1.025, 1.05, 1.1 };
+    double qout[] = { 1.05, 1.05, 1.05, 1.05 };
     T(q_test(h, 1, qin, 4, qout));
 
+    double h_1[] = { 1,1 };
+    double qin_1[] = { 0, 1 };
+    double qout_1[] = { 1+0.1/3, 1+0.2/3 };
+    T(q_test(h_1, 2, qin_1, 2, qout_1));
+
+    double h_2[] = { 1,1,1 };
+    double qin_2[] = { 0, .5, 1 };
+    double qout_2[] = { 1.025, 1.05, 1.075 };
+    T(q_test(h_2, 3, qin_2, 3, qout_2));
+
     double qin2[] = { 0, 0.95, 0.99, 1.0 };
-    double qout2[] = { 0, 0.4355, 0.4391, 0.44 };
+    double qout2[] = { 0, 0.435, 0.435, 0.435 };
     T(q_test(s1, 9, qin2, 4, qout2));
 
     double s3[] = { 1.0, 2.0 };
     double qin3[] = { 0.5 };
-    double qout3[] = { 1.1 };
+    double qout3[] = { 1.05 };
     T(q_test(s3, 2, qin3, 1, qout3));
 
     double s4[] = { 1.0, 1e200 }; // out of range -> nan bucket
     double qin4[] = { 0, 1 };
-    double qout4[] = { 1.0, 1.1 };
+    double qout4[] = { 1.05, 1.05 };
     T(q_test(s4, 2, qin4, 2, qout4));
     T(mean_test(s4, 2, 1.05));
 
     double s5[] = { 1e200, 1e200, 1e200,  0, 0, 1e-20, 1e-20, 1e-20, 1e-10};
     double qin5[] = { 0, 1 };
-    double qout5[] = { 0, 1.1e-10 };
+    double qout5[] = { 0, 1.05e-10 };
     T(q_test(s5, 9, qin5, 2, qout5));
 
     double s6[] = { 0, 1 };

--- a/src/test/runTest.sh
+++ b/src/test/runTest.sh
@@ -52,8 +52,11 @@ export LUA_INIT=''
 arg=''
 DEBUG_PREFIX=""
 
-echo "Running: $ $LUA_BIN $LUA_ARGS -l histogram_c_test -e \"histogram_c_test.runTests()\""
+echo "Lua histogram_c_test"
 $LUA_BIN $LUA_ARGS -l histogram_c_test -e "histogram_c_test.runTests()"
+
+echo "Lua circllhist_test"
+$LUA_BIN $LUA_ARGS -l circllhist_test -e "circllhist_test.runTests()"
 
 pushd ../python
 


### PR DESCRIPTION
This PR changes the quantile calculation formula to follow the following heuristic:

```
      /*
       * We represent the bucket by n independent random variables, that are
       * uniformly distributed across the bucket. Let X_1 < X_2 < ... < X_n
       * be a sorted version of these. X_k will be Beta(k,n+1-k) distributed.
       * The expected location of X_k is:
       *
       *    x_k  =  bucket_left + k/(n+1) * bucket_width
       *
       * [ Variant: The ML estimator for the bucket position is
       *            at (k-1)/(n-1) for n>1 and 1/2 if n=1 ]
       *
       * A q-quantile for the bucket, will be represented by the sample number:
       *
       *  (q = 0)  k = 1
       *  (q > 1)  k = ceil(q*n)
       *
       * so that q=0 => k=1 and q=1 => k=n. This corresponds to Type=1 quantiles
       * in the Hyndman-Fan list (Statistical Computing, 1996).
       */
```

In order to simplify writing tests for this change, it made sense to put in some work into the lua bindings.
The object oriented wrapper circllhist.lua was backported form IRONdb, together with a full set of tests.

Furthermore:
- We pull in changes from the error_min branch (#42), add more tests and correct a typo.
- We fix an edge case in count_below()
- We fix an edge case in stddev()