### PR TITLE
Calculations for circllhist_print

### DIFF
--- a/src/circllhist.c
+++ b/src/circllhist.c
@@ -45,7 +45,7 @@
 
 #include "circllhist.h"
 
-hist_allocator_t default_allocator = {
+const hist_allocator_t default_allocator = {
   .malloc = malloc,
   .calloc = calloc,
   .free = free
@@ -145,7 +145,7 @@ struct histogram {
   uint16_t allocd; //!< number of allocated bv pairs
   uint16_t used;   //!< number of used bv pairs
   uint32_t fast: 1;
-  hist_allocator_t *allocator;
+  const hist_allocator_t *allocator;
   struct hist_bv_pair *bvs; //!< pointer to bv-pairs
 };
 
@@ -1365,7 +1365,7 @@ hist_alloc(void) {
 }
 
 histogram_t *
-hist_alloc_with_allocator(hist_allocator_t *allocator) {
+hist_alloc_with_allocator(const hist_allocator_t *allocator) {
   return hist_alloc_nbins_with_allocator(0, allocator);
 }
 
@@ -1375,7 +1375,7 @@ hist_alloc_nbins(int nbins) {
 }
 
 histogram_t *
-hist_alloc_nbins_with_allocator(int nbins, hist_allocator_t *allocator) {
+hist_alloc_nbins_with_allocator(int nbins, const hist_allocator_t *allocator) {
   histogram_t *tgt;
   if(nbins < 1) nbins = DEFAULT_HIST_SIZE;
   if(nbins > MAX_HIST_BINS) nbins = MAX_HIST_BINS;
@@ -1392,7 +1392,7 @@ hist_fast_alloc(void) {
 }
 
 histogram_t *
-hist_fast_alloc_with_allocator(hist_allocator_t *allocator) {
+hist_fast_alloc_with_allocator(const hist_allocator_t *allocator) {
   return hist_fast_alloc_nbins_with_allocator(0, allocator);
 }
 
@@ -1402,7 +1402,7 @@ hist_fast_alloc_nbins(int nbins) {
 }
 
 histogram_t *
-hist_fast_alloc_nbins_with_allocator(int nbins, hist_allocator_t *allocator) {
+hist_fast_alloc_nbins_with_allocator(int nbins, const hist_allocator_t *allocator) {
   struct histogram_fast *tgt;
   if(nbins < 1) nbins = DEFAULT_HIST_SIZE;
   if(nbins > MAX_HIST_BINS) nbins = MAX_HIST_BINS;
@@ -1415,12 +1415,12 @@ hist_fast_alloc_nbins_with_allocator(int nbins, hist_allocator_t *allocator) {
 }
 
 histogram_t *
-hist_clone(histogram_t *other) {
+hist_clone(const histogram_t *other) {
   return hist_clone_with_allocator(other, &default_allocator);
 }
 
 histogram_t *
-hist_clone_with_allocator(histogram_t *other, hist_allocator_t *allocator)
+hist_clone_with_allocator(const histogram_t *other, const hist_allocator_t *allocator)
 {
   histogram_t *tgt = NULL;
   int i = 0;
@@ -1446,7 +1446,7 @@ hist_clone_with_allocator(histogram_t *other, hist_allocator_t *allocator)
 void
 hist_free(histogram_t *hist) {
   if(hist == NULL) return;
-  hist_allocator_t *a = hist->allocator;
+  const hist_allocator_t *a = hist->allocator;
   if(hist->bvs != NULL) a->free(hist->bvs);
   if(hist->fast) {
     int i;
@@ -1458,7 +1458,7 @@ hist_free(histogram_t *hist) {
 }
 
 histogram_t *
-hist_compress_mbe(histogram_t *hist, int8_t mbe) {
+hist_compress_mbe(const histogram_t *hist, int8_t mbe) {
   histogram_t *hist_compressed = hist_alloc();
   if(!hist) return hist_compressed;
   int total = hist_bucket_count(hist);

--- a/src/circllhist.h
+++ b/src/circllhist.h
@@ -119,21 +119,21 @@ API_EXPORT(histogram_t *) hist_fast_alloc(void);
 //! Create a fast-histogram with preallocated bins, uses default allocator
 API_EXPORT(histogram_t *) hist_fast_alloc_nbins(int nbins);
 //! Create an exact copy of other, uses default allocator
-API_EXPORT(histogram_t *) hist_clone(histogram_t *other);
+API_EXPORT(histogram_t *) hist_clone(const histogram_t *other);
 
 //! Create a new histogram, uses custom allocator
-API_EXPORT(histogram_t *) hist_alloc_with_allocator(hist_allocator_t *alloc);
+API_EXPORT(histogram_t *) hist_alloc_with_allocator(const hist_allocator_t *alloc);
 //! Create a new histogram with preallocated bins, uses custom allocator
-API_EXPORT(histogram_t *) hist_alloc_nbins_with_allocator(int nbins, hist_allocator_t *alloc);
+API_EXPORT(histogram_t *) hist_alloc_nbins_with_allocator(int nbins, const hist_allocator_t *alloc);
 //! Create a fast-histogram
 /*! Fast allocations consume 2kb + N * 512b more memory
  *  where N is the number of used exponents.  It allows for O(1) increments for
  *  prexisting keys, uses custom allocator */
-API_EXPORT(histogram_t *) hist_fast_alloc_with_allocator(hist_allocator_t *alloc);
+API_EXPORT(histogram_t *) hist_fast_alloc_with_allocator(const hist_allocator_t *alloc);
 //! Create a fast-histogram with preallocated bins, uses custom allocator
-API_EXPORT(histogram_t *) hist_fast_alloc_nbins_with_allocator(int nbins, hist_allocator_t *alloc);
+API_EXPORT(histogram_t *) hist_fast_alloc_nbins_with_allocator(int nbins, const hist_allocator_t *alloc);
 //! Create an exact copy of other, uses custom allocator
-API_EXPORT(histogram_t *) hist_clone_with_allocator(histogram_t *other, hist_allocator_t *alloc);
+API_EXPORT(histogram_t *) hist_clone_with_allocator(const histogram_t *other, const hist_allocator_t *alloc);
 
 //! Free a (fast-) histogram, frees with allocator chosen during the alloc/clone
 API_EXPORT(void) hist_free(histogram_t *hist);
@@ -202,7 +202,7 @@ API_EXPORT(void) hist_remove_zeroes(histogram_t *h);
 //! \param hist
 //! \param mbe the Minimum Bucket Exponent
 //! \return the compressed histogram as new value
-API_EXPORT(histogram_t *) hist_compress_mbe(histogram_t *h, int8_t mbe);
+API_EXPORT(histogram_t *) hist_compress_mbe(const histogram_t *h, int8_t mbe);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Analytics

--- a/src/circllhist_print.c
+++ b/src/circllhist_print.c
@@ -4,60 +4,133 @@
 #include <math.h>
 #include <getopt.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include "circllhist.h"
 
-enum ofmt {
-  JSON
-} output_format;
+bool cumulative = false;
 
-void help() {
+void help(const char *prog) {
+  printf("%s:\n", prog);
   printf("\t-h\t\thelp\n");
-  printf("\t-f <type>\toutput format\n");
+  printf("\t-a <val>\tcompute number of samples above <val>\n");
+  printf("\t-b <val>\tcompute number of samples below <val>\n");
+  printf("\t-p <0-100>\tcompute approximate percentile\n");
+  printf("\t-i <val>\tcompute approximate inverse quantile at <val>\n");
+  printf("\t-C\t\tcalculate difference between cumulative histograms\n");
   printf("\t[hist1 [hist2 [...]]]\n\n");
   printf("If no hists are specified, stdin is read\n");
+  printf("\n\nExample:\n\n");
+  printf("\tcurl url |\n\t  jq -r .stat._value |\n\t  %s -i 0.2 -p 0 -p 100 -p 99 -p 99.999 -p 50\n\n", prog);
+  printf("\tThis will fetch the document at URL, extract the b64 encoded histogram\n");
+  printf("\tprinting the inverse quantile at 0.2 (seconds)\n");
+  printf("\tand the p0, p50, p99, p99.999, and p100\n");
 }
 
 void print_hist(histogram_t *hist) {
-  switch(output_format) {
-    case JSON:
-      printf("{");
-      int cnt = hist_bucket_count(hist);
-      for(int i=0; i<cnt; i++) {
-        double v;
-        uint64_t vc;
-        hist_bucket_idx(hist, i, &v, &vc);
-        printf("%s\"%g\":%" PRIu64, i ? "," : "", v, vc);
-      }
-      printf("}\n");
-      break;
+  printf("{");
+  int cnt = hist_bucket_count(hist);
+  for(int i=0; i<cnt; i++) {
+    double v;
+    uint64_t vc;
+    hist_bucket_idx(hist, i, &v, &vc);
+    printf("%s\"%g\":%" PRIu64, i ? "," : "", v, vc);
   }
+  printf("}\n");
 }
 
-void decode_print(char *buff) {
+histogram_t *decode(char *buff) {
   histogram_t *hist = hist_alloc();
   if(hist_deserialize_b64(hist, buff, strlen(buff)) <= -1) {
     fprintf(stderr, "histogram invalid\n");
+    hist_free(hist);
+    return NULL;
   }
-  else {
-    print_hist(hist);
+  return hist;
+}
+
+histogram_t *calc_cum(const histogram_t *base, const histogram_t *now, bool cumulative) {
+  histogram_t *result = hist_clone(now);
+  if(cumulative && !base) return NULL;
+  if(!cumulative) return result;
+  if(hist_subtract(result, &base, 1) == 0) return result;
+  fprintf(stderr, "histogram cumulative calculation reset\n");
+  hist_free(result);
+  return NULL;
+}
+
+struct calcs {
+  int cnt;
+  double *elements;
+} above = { 0 }, below = { 0 }, quantiles = { 0 }, invquantiles = { 0 };
+
+void add_to(struct calcs *c, double v) {
+  c->elements = realloc(c->elements, sizeof(double) * (1 + c->cnt));
+  c->elements[c->cnt++] = v;
+}
+
+void print(histogram_t *hist) {
+  int i;
+  if(above.cnt || below.cnt || quantiles.cnt) {
+    printf("{");
+    for(i=0; i<above.cnt; i++) {
+      uint64_t cnt = hist_approx_count_above(hist, above.elements[i]);
+      printf("\"above(%g)\":%zu,", above.elements[i], (size_t)cnt);
+    }
+    for(i=0; i<below.cnt; i++) {
+      uint64_t cnt = hist_approx_count_below(hist, below.elements[i]);
+      printf("\"below(%g)\":%zu,", below.elements[i], (size_t)cnt);
+    }
+    double vals[quantiles.cnt];
+    hist_approx_quantile(hist, quantiles.elements, quantiles.cnt, vals);
+    for(i=0; i<quantiles.cnt; i++) {
+      printf("\"p(%f%%)\":%g,", quantiles.elements[i] * 100, vals[i]);
+    }
+    double qvals[invquantiles.cnt];
+    hist_approx_inverse_quantile(hist, invquantiles.elements, invquantiles.cnt, qvals);
+    for(i=0; i<invquantiles.cnt; i++) {
+      printf("\"invq(%f)\":%g,", invquantiles.elements[i], qvals[i]);
+    }
+    printf("\"count\":%zu}\n", hist_sample_count(hist));
   }
-  hist_free(hist);
+  else print_hist(hist);
+}
+
+static int double_compare(const void *lv, const void *rv) {
+  double l = *(double *)lv;
+  double r = *(double *)rv;
+  if(l < r) return -1;
+  if(l > r) return 1;
+  return 0;
 }
 
 int main(int argc, char **argv) {
+  double percent;
   char buff[256*1024];
   int opt;
-  while((opt = getopt(argc, argv, "hf:")) != -1) {
+  while((opt = getopt(argc, argv, "ha:b:p:i:C")) != -1) {
     switch(opt) {
-    case 'f':
-      if(!strcmp(optarg, "json")) output_format = JSON;
-      else {
-        fprintf(stderr, "unrecognized format: %s\n", optarg);
+    case 'a':
+      add_to(&above, atof(optarg));
+      break;
+    case 'b':
+      add_to(&below, atof(optarg));
+      break;
+    case 'i':
+      add_to(&invquantiles, atof(optarg));
+      break;
+    case 'p':
+      percent = atof(optarg);
+      if(percent < 0 || percent > 100) {
+        fprintf(stderr, "Invalid percentile %f\n", percent);
         exit(-1);
       }
+      add_to(&quantiles, percent/100);
+      break;
+    case 'C':
+      cumulative = true;
       break;
     case 'h':
-      help();
+      help(argv[0]);
       exit(0);
     default:
       fprintf(stderr, "unrecognized option: -%c\n", opt);
@@ -65,18 +138,35 @@ int main(int argc, char **argv) {
       break;
     }
   }
+
+  if(quantiles.cnt) qsort(quantiles.elements, quantiles.cnt, sizeof(double), double_compare);
+
+  histogram_t *last = NULL;
   if(optind < argc) {
     for(int i=optind; i<argc; i++) {
       if(strlen(argv[i]) > sizeof(buff)-1) {
         fprintf(stderr, "histogram too large\n");
         exit(-1);
       }
-      decode_print(argv[i]);
+      histogram_t *hist = decode(argv[i]);
+      if(hist) {
+        histogram_t *toprint = calc_cum(last, hist, cumulative);
+        if(toprint) print(toprint);
+        if(last) hist_free(last);
+        last = hist;
+      }
     }
   } else {
     while(NULL != fgets(buff, sizeof(buff), stdin)) {
-      decode_print(buff);
+      histogram_t *hist = decode(buff);
+      if(hist) {
+        histogram_t *toprint = calc_cum(last, hist, cumulative);
+        if(toprint) print(toprint);
+        if(last) hist_free(last);
+        last = hist;
+      }
     }
   }
+  if(last) hist_free(last);
   return 0;
 }

--- a/src/circllhist_print.c
+++ b/src/circllhist_print.c
@@ -26,7 +26,7 @@ void help(const char *prog) {
   printf("\tand the p0, p50, p99, p99.999, and p100\n");
 }
 
-void print_hist(histogram_t *hist) {
+void print_hist(const histogram_t *hist) {
   printf("{");
   int cnt = hist_bucket_count(hist);
   for(int i=0; i<cnt; i++) {
@@ -38,7 +38,7 @@ void print_hist(histogram_t *hist) {
   printf("}\n");
 }
 
-histogram_t *decode(char *buff) {
+histogram_t *decode(const char *buff) {
   histogram_t *hist = hist_alloc();
   if(hist_deserialize_b64(hist, buff, strlen(buff)) <= -1) {
     fprintf(stderr, "histogram invalid\n");
@@ -68,7 +68,7 @@ void add_to(struct calcs *c, double v) {
   c->elements[c->cnt++] = v;
 }
 
-void print(histogram_t *hist) {
+void print(const histogram_t *hist) {
   int i;
   if(above.cnt || below.cnt || quantiles.cnt) {
     printf("{");


### PR DESCRIPTION
Add new options to circllhist_print to allow various histogram
calculationgs to be performed.  This is a simple accessibility wrapper
for people interogating otherwise opaque (or overwhelming) histograms.