### PR TITLE
Remove alias syntax to support macOS build

### DIFF
--- a/src/circllhist.c
+++ b/src/circllhist.c
@@ -682,8 +682,12 @@ hist_clamp(histogram_t *hist, double lower, double upper) {
   if(needs_cull) hist_remove_zeroes(hist);
 }
 
-uint64_t __attribute__((alias("hist_approx_count_below_inclusive"))) hist_approx_count_below(const histogram_t *hist, double threshold);
-uint64_t __attribute__((alias("hist_approx_count_above_inclusive"))) hist_approx_count_above(const histogram_t *hist, double threshold);
+uint64_t hist_approx_count_below(const histogram_t *hist, double threshold) {
+  return hist_approx_count_below_inclusive(hist, threshold);
+}
+uint64_t hist_approx_count_above(const histogram_t *hist, double threshold) {
+  return hist_approx_count_above_inclusive(hist, threshold);
+}
 
 uint64_t
 hist_approx_count_below_inclusive(const histogram_t *hist, double threshold) {


### PR DESCRIPTION
When building for macOS as part of https://github.com/envoyproxy/envoy/pull/40967, the compiler yields an error

> external/com_github_openhistogram_libcircllhist/src/circllhist.c:685:25: error: aliases are not supported on darwin
  685 | uint64_t __attribute__((alias("hist_approx_count_below_inclusive"))) hist_approx_count_below(const histogram_t *hist, double threshold);
      |                         ^
> external/com_github_openhistogram_libcircllhist/src/circllhist.c:686:25: error: aliases are not supported on darwin
  686 | uint64_t __attribute__((alias("hist_approx_count_above_inclusive"))) hist_approx_count_above(const histogram_t *hist, double threshold);

This PR simply replaces the alias syntax with the same implementation.
